### PR TITLE
Update content.js

### DIFF
--- a/content.js
+++ b/content.js
@@ -1,4 +1,4 @@
-// Zoom site forwards the page to ?status=success after the meeting is launched.
-if (window.location.search.includes("status=success")) {
+// Zoom site forwards the page to #success after the meeting is launched.
+if (window.location.hash.includes("#success")) {
   chrome.runtime.sendMessage({ close: true });
 }


### PR DESCRIPTION
Fixes for Zoom's re-design.

It used to redirect to ?status=success and now redirects to #success.